### PR TITLE
add configurable yaw/roll control selection

### DIFF
--- a/Aviator1280.conf
+++ b/Aviator1280.conf
@@ -66,6 +66,7 @@ handlers:
      brakeInput = 0
      rcfreeze = 1 --export
      GND_Altitude=0 --export
+     QEyaw_ADroll = false --export use different (alpha) keys for control
 
      Nav = Navigator.new(system, core, unit)
      Nav.axisCommandManager:setupCustomTargetSpeedRanges(axisCommandId.longitudinal, {1000, 5000, 10000, 20000, 30000})
@@ -4280,16 +4281,36 @@ handlers:
    lua: pitchInput = 0
   actionStart:
    args: [left]
-   lua: rollInput = rollInput - 1
+   lua: |
+    if not QEyaw_ADroll then
+     rollInput = rollInput - 1
+    else
+     yawInput = yawInput + 1
+    end
   actionStop:
    args: [left]
-   lua: rollInput = 0
+   lua: |
+    if not QEyaw_ADroll then
+     rollInput = 0
+    else
+     yawInput = 0
+    end
   actionStart:
    args: [right]
-   lua: rollInput = rollInput + 1
+   lua: |
+    if not QEyaw_ADroll then
+     rollInput = rollInput + 1
+    else
+     yawInput = yawInput - 1
+    end
   actionStop:
    args: [right]
-   lua: rollInput = 0
+   lua: |
+    if not QEyaw_ADroll then
+     rollInput = 0
+    else
+     yawInput = 0
+    end
   actionStart:
    args: [straferight]
    lua: Nav.axisCommandManager:updateCommandFromActionStart(axisCommandId.lateral, 1.0)
@@ -4387,16 +4408,36 @@ handlers:
     end
   actionStart:
    args: [yawright]
-   lua: yawInput = yawInput - 1
+   lua: |
+    if (QEyaw_ADroll == false) then
+     yawInput = yawInput - 1
+    else
+     rollInput = rollInput + 1
+    end
   actionStop:
    args: [yawright]
-   lua: yawInput = 0
+   lua: |
+    if (QEyaw_ADroll == false) then
+     yawInput = 0
+    else
+     rollInput = 0
+    end
   actionStart:
    args: [yawleft]
-   lua: yawInput = yawInput + 1
+   lua: |
+    if (QEyaw_ADroll == false) then
+     yawInput = yawInput + 1
+    else
+     rollInput = rollInput - 1
+    end
   actionStop:
    args: [yawleft]
-   lua: yawInput = 0
+   lua: |
+    if (QEyaw_ADroll == false) then
+     yawInput = 0
+    else
+     rollInput = 0
+    end
   actionStart:
    args: [brake]
    lua: |

--- a/Aviator1280_(Fuel Module).conf
+++ b/Aviator1280_(Fuel Module).conf
@@ -66,6 +66,7 @@ handlers:
      brakeInput = 0
      rcfreeze = 1 --export
      GND_Altitude=0 --export
+     QEyaw_ADroll = false --export use different (alpha) keys for control
 
      Nav = Navigator.new(system, core, unit)
      Nav.axisCommandManager:setupCustomTargetSpeedRanges(axisCommandId.longitudinal, {1000, 5000, 10000, 20000, 30000})
@@ -4438,16 +4439,36 @@ handlers:
    lua: pitchInput = 0
   actionStart:
    args: [left]
-   lua: rollInput = rollInput - 1
+   lua: |
+    if not QEyaw_ADroll then
+     rollInput = rollInput - 1
+    else
+     yawInput = yawInput + 1
+    end
   actionStop:
    args: [left]
-   lua: rollInput = 0
+   lua: |
+    if not QEyaw_ADroll then
+     rollInput = 0
+    else
+     yawInput = 0
+    end
   actionStart:
    args: [right]
-   lua: rollInput = rollInput + 1
+   lua: |
+    if not QEyaw_ADroll then
+     rollInput = rollInput + 1
+    else
+     yawInput = yawInput - 1
+    end
   actionStop:
    args: [right]
-   lua: rollInput = 0
+   lua: |
+    if not QEyaw_ADroll then
+     rollInput = 0
+    else
+     yawInput = 0
+    end
   actionStart:
    args: [straferight]
    lua: Nav.axisCommandManager:updateCommandFromActionStart(axisCommandId.lateral, 1.0)
@@ -4545,16 +4566,36 @@ handlers:
     end
   actionStart:
    args: [yawright]
-   lua: yawInput = yawInput - 1
+   lua: |
+    if (QEyaw_ADroll == false) then
+     yawInput = yawInput - 1
+    else
+     rollInput = rollInput + 1
+    end
   actionStop:
    args: [yawright]
-   lua: yawInput = 0
+   lua: |
+    if (QEyaw_ADroll == false) then
+     yawInput = 0
+    else
+     rollInput = 0
+    end
   actionStart:
    args: [yawleft]
-   lua: yawInput = yawInput + 1
+   lua: |
+    if (QEyaw_ADroll == false) then
+     yawInput = yawInput + 1
+    else
+     rollInput = rollInput - 1
+    end
   actionStop:
    args: [yawleft]
-   lua: yawInput = 0
+   lua: |
+    if (QEyaw_ADroll == false) then
+     yawInput = 0
+    else
+     rollInput = 0
+    end
   actionStart:
    args: [brake]
    lua: |


### PR DESCRIPTION
I am used to the old-school style keys from Alpha, where Q/E did yaw and A/D did roll.

This should make it user-configurable (via "Edit Lua Parameters") but be transparent to players who do not wish to change it from its current setup.